### PR TITLE
source code in java 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0.2</version>
                 <configuration>
-                    <source>1.5</source>
+                    <source>1.6</source>
                     <target>1.5</target>
                 </configuration>
             </plugin>


### PR DESCRIPTION
i think that @Override on methods that implements interfaces and do not override implementation is 1.6 only
so i switched maven-compiler-plugin to sources 1.6
