### PR TITLE
path2CN bugfix

### DIFF
--- a/src/main/java/com/greenlaw110/rythm/resource/TemplateResourceBase.java
+++ b/src/main/java/com/greenlaw110/rythm/resource/TemplateResourceBase.java
@@ -132,8 +132,9 @@ public abstract class TemplateResourceBase implements ITemplateResource {
         //    in the end
         //int lastDotPos = path.lastIndexOf(".");
         //path = path.substring(0, lastDotPos);
-        return path.replace('/', '_').replace('\\', '_').replace('.', '_').replace('-', '_');
-        //return path.replace('/', '.').replace('\\', '.').replace('-', '_');
+        
+        // replace characters that are invalid in a java identifier with '_'
+        return path.replaceAll("[.\\\\/ -]", "_");
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
This is a bugfix for the path2CN function for paths that include spaces. I switched to the replaceAll function since it becomes more readable when the list of invalid characters grows.
