### PR TITLE
Do not detect template changes when "rythm.loadPreCompiled" is true

### DIFF
--- a/src/main/java/com/greenlaw110/rythm/internal/compiler/TemplateClassCache.java
+++ b/src/main/java/com/greenlaw110/rythm/internal/compiler/TemplateClassCache.java
@@ -65,12 +65,16 @@ public class TemplateClassCache {
                 hash.append((char) read);
                 offset++;
             }
-            String curHash = hash(tc);
-            if (!curHash.equals(hash.toString())) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Bytecode too old (%s != %s)", hash, curHash);
-                }
-                return;
+            
+            //check hash only in non precompiled mode
+            if(!engine.loadPreCompiled()){
+	            String curHash = hash(tc);
+	            if (!curHash.equals(hash.toString())) {
+	                if (logger.isTraceEnabled()) {
+	                    logger.trace("Bytecode too old (%s != %s)", hash, curHash);
+	                }
+	                return;
+	            }
             }
 
             // --- load java source


### PR DESCRIPTION
Hi,

I use the excellent Rythm as a Playframework template engine with play-rythm. I want deliver my application in production without the 'app' directory. And when I used the Play precompiled mode, Rythm try to generate java code and fail because the md5 of the VirtualFile is different. I think it's a small mistake. I think that in production mode the template engine must used only precompiled templates.

This patch is a proposal to fix that. What do you think about it?

Regards,
Jérôme BENOIS.
