### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/rythmengine/Rythm.java
+++ b/src/main/java/org/rythmengine/Rythm.java
@@ -427,6 +427,10 @@ public class Rythm {
     
     public static final class RenderTime {
         private static final ThreadLocal<Escape> escape_ = new ThreadLocal<Escape>();
+
+        private RenderTime() {
+        }
+
         public static void setEscape(Escape e) {
             escape_.set(e);
         }

--- a/src/main/java/org/rythmengine/extension/IByteCodeEnhancer.java
+++ b/src/main/java/org/rythmengine/extension/IByteCodeEnhancer.java
@@ -49,5 +49,8 @@ public interface IByteCodeEnhancer {
                 return new byte[0];
             }
         };
+
+        private INSTS() {
+        }
     }
 }

--- a/src/main/java/org/rythmengine/extension/ISourceCodeEnhancer.java
+++ b/src/main/java/org/rythmengine/extension/ISourceCodeEnhancer.java
@@ -121,5 +121,8 @@ public interface ISourceCodeEnhancer {
                 return null;
             }
         };
+
+        private INSTS() {
+        }
     }
 }

--- a/src/main/java/org/rythmengine/internal/CacheKey.java
+++ b/src/main/java/org/rythmengine/internal/CacheKey.java
@@ -14,6 +14,9 @@ import java.util.Locale;
  * To change this template use File | Settings | File Templates.
  */
 public class CacheKey {
+    private CacheKey() {
+    }
+
     public static String i18nMsg(ITemplate template, String key, boolean useFormat) {
         return i18nMsg(template, key, useFormat, null);
     }

--- a/src/main/java/org/rythmengine/internal/compiler/ParamTypeInferencer.java
+++ b/src/main/java/org/rythmengine/internal/compiler/ParamTypeInferencer.java
@@ -31,6 +31,9 @@ import java.util.Map;
  */
 public class ParamTypeInferencer {
 
+    private ParamTypeInferencer() {
+    }
+
     public static String typeTransform(String type) {
         type = type.trim();
         if (type.contains("Boolean") && type.matches("(.*[^a-zA-Z0-9_]+)?boolean([^a-zA-Z0-9_].*|$)")) return type.replace("Boolean","boolean");

--- a/src/main/java/org/rythmengine/logger/Logger.java
+++ b/src/main/java/org/rythmengine/logger/Logger.java
@@ -34,6 +34,9 @@ import java.util.Map;
  */
 public class Logger {
 
+    private Logger() {
+    }
+
     private static class Proxy implements ILogger {
         private Class<?> c_;
         private ILogger l_;

--- a/src/main/java/org/rythmengine/sandbox/Base64.java
+++ b/src/main/java/org/rythmengine/sandbox/Base64.java
@@ -50,6 +50,9 @@ class Base64 {
         for (int i = 0; i < 64; i++) map2[map1[i]] = (byte) i;
     }
 
+    private Base64() {
+    }
+
     /**
      * Encodes a byte array into Base64 format.
      * No blanks or line breaks are inserted in the output.

--- a/src/main/java/org/rythmengine/utils/Eval.java
+++ b/src/main/java/org/rythmengine/utils/Eval.java
@@ -28,6 +28,9 @@ import java.util.Map;
  * Evaluate an object and return boolean value by convention
  */
 public class Eval {
+    private Eval() {
+    }
+
     /**
      * return <code>true</code> if the specified byte <code>b != 0</code>
      * @param b

--- a/src/main/java/org/rythmengine/utils/F.java
+++ b/src/main/java/org/rythmengine/utils/F.java
@@ -30,6 +30,9 @@ import java.util.Map;
 // Most of the code come from Play!Framework F.java, under Apache License 2.0
 public class F {
 
+    private F() {
+    }
+
     public static interface Action0 {
 
         void invoke();

--- a/src/main/java/org/rythmengine/utils/HashCode.java
+++ b/src/main/java/org/rythmengine/utils/HashCode.java
@@ -9,6 +9,9 @@ public class HashCode {
     private static final int HC_INIT = 17;
     private static final int HC_FACT = 37;
 
+    private HashCode() {
+    }
+
     public final static int iterableHashCode(Iterable<?> it) {
         int ret = HC_INIT;
         for (Object o : it) {

--- a/src/main/java/org/rythmengine/utils/I18N.java
+++ b/src/main/java/org/rythmengine/utils/I18N.java
@@ -39,6 +39,9 @@ public class I18N {
 
     private static final ILogger logger = Logger.get(I18N.class);
 
+    private I18N() {
+    }
+
     /**
      * Return a {@link org.rythmengine.template.ITemplate template}'s current locale, or
      * the the {@link org.rythmengine.RythmEngine#get() current engine}'s 

--- a/src/main/java/org/rythmengine/utils/IO.java
+++ b/src/main/java/org/rythmengine/utils/IO.java
@@ -28,6 +28,9 @@ import java.net.URL;
 // Most of the code come from Play!Framework IO.java, under Apache License 2.0
 public class IO {
 
+    private IO() {
+    }
+
     /**
      * Read file content to a String (always use utf-8)
      *

--- a/src/main/java/org/rythmengine/utils/Time.java
+++ b/src/main/java/org/rythmengine/utils/Time.java
@@ -36,6 +36,9 @@ public class Time {
     static Pattern minutes = Pattern.compile("^([0-9]+)mi?n$");
     static Pattern seconds = Pattern.compile("^([0-9]+)s$");
 
+    private Time() {
+    }
+
     /**
      * Parse a duration
      *

--- a/src/test/java/org/rythmengine/issue/Gh170Helper.java
+++ b/src/test/java/org/rythmengine/issue/Gh170Helper.java
@@ -17,6 +17,9 @@ public class Gh170Helper {
     private static final String TMPL_NAME = "gh170helper.txt";
     private static File tmplHome;
 
+    private Gh170Helper() {
+    }
+
     private static String content() {
         return "@args String who\nHello @who";
     }

--- a/src/test/java/org/rythmengine/issue/Gh174Helper.java
+++ b/src/test/java/org/rythmengine/issue/Gh174Helper.java
@@ -17,6 +17,9 @@ public class Gh174Helper {
     private static final String TMPL_NAME = "gh174helper.txt";
     private static File tmplHome;
 
+    private Gh174Helper() {
+    }
+
     private static String contentA() {
         return "@args String who\nHello @who";
     }

--- a/src/test/java/org/rythmengine/template/GhIssue215.java
+++ b/src/test/java/org/rythmengine/template/GhIssue215.java
@@ -3,6 +3,9 @@ package org.rythmengine.template;
 import org.rythmengine.utils.Range;
 
 public class GhIssue215 {
+    private GhIssue215() {
+    }
+
     public static void foo() {
         TemplateBase.__Itr itr = TemplateBase.__Itr.ofRange(Range.valueOf("1.. 5"));
         System.out.println(itr.size());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.