### PR TITLE
to lower locale fixes (for i.e. Turkish language)

### DIFF
--- a/src/main/java/org/rythmengine/conf/RythmConfigurationKey.java
+++ b/src/main/java/org/rythmengine/conf/RythmConfigurationKey.java
@@ -1031,7 +1031,7 @@ public enum RythmConfigurationKey {
 
     private static Map<String, RythmConfigurationKey> lookup = new HashMap<String, RythmConfigurationKey>(50); static {
         for (RythmConfigurationKey k : values()) {
-            lookup.put(k.getKey().toLowerCase(), k);
+            lookup.put(k.getKey().toLowerCase(Locale.US), k);
         }
     }
 
@@ -1043,7 +1043,7 @@ public enum RythmConfigurationKey {
      */
     public static RythmConfigurationKey valueOfIgnoreCase(String s) {
         if (S.empty(s)) throw new IllegalArgumentException();
-        return lookup.get(s.trim().toLowerCase());
+        return lookup.get(s.trim().toLowerCase(Locale.US));
     }
 
 }

--- a/src/main/java/org/rythmengine/internal/CodeBuilder.java
+++ b/src/main/java/org/rythmengine/internal/CodeBuilder.java
@@ -118,7 +118,7 @@ public class CodeBuilder extends TextBuilder {
         private static String defValTransform(String type, String defVal) {
             if (S.isEmpty(defVal)) return null;
             if ("String".equalsIgnoreCase(type) && "null".equalsIgnoreCase(defVal)) return "\"\"";
-            if ("boolean".equalsIgnoreCase(type)) defVal = defVal.toLowerCase();
+            if ("boolean".equalsIgnoreCase(type)) defVal = defVal.toLowerCase(Locale.US);
             if ("long".equalsIgnoreCase(type) && defVal.matches("[0-9]+")) return defVal + "L";
             if ("float".equalsIgnoreCase(type) && defVal.matches("[0-9]+")) return defVal + "f";
             if ("double".equalsIgnoreCase(type) && defVal.matches("[0-9]+")) return defVal + "d";

--- a/src/main/java/org/rythmengine/internal/Keyword.java
+++ b/src/main/java/org/rythmengine/internal/Keyword.java
@@ -5,6 +5,8 @@
  */
 package org.rythmengine.internal;
 
+import java.util.Locale;
+
 public enum Keyword implements IKeyword {
     /**
      * Assign enclosed part into a String variable
@@ -173,11 +175,11 @@ public enum Keyword implements IKeyword {
     private final String s;
 
     private Keyword() {
-        this.s = name().toLowerCase();
+        this.s = name().toLowerCase(Locale.US);
     }
 
     private Keyword(String s) {
-        this.s = (null == s) ? name().toLowerCase() : s;
+        this.s = (null == s) ? name().toLowerCase(Locale.US) : s;
     }
 
     @Override
@@ -187,6 +189,6 @@ public enum Keyword implements IKeyword {
 
     @Override
     public boolean isRegexp() {
-        return !s.equals(name().toLowerCase());
+        return !s.equals(name().toLowerCase(Locale.US));
     }
 }

--- a/src/main/java/org/rythmengine/internal/dialect/DialectBase.java
+++ b/src/main/java/org/rythmengine/internal/dialect/DialectBase.java
@@ -57,7 +57,7 @@ public abstract class DialectBase implements IDialect {
     }
 
     public IParser createBuildInParser(String keyword, IContext context) {
-        KeywordParserFactory f = keywords.get(keyword.toLowerCase());
+        KeywordParserFactory f = keywords.get(keyword.toLowerCase(Locale.US));
         if (null == f) {
             for (Map.Entry<String, KeywordParserFactory> entry : keywords2.entrySet()) {
                 if (keyword.matches(entry.getKey())) {

--- a/src/main/java/org/rythmengine/sandbox/RythmSecurityManager.java
+++ b/src/main/java/org/rythmengine/sandbox/RythmSecurityManager.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FilePermission;
 import java.net.InetAddress;
 import java.security.Permission;
+import java.util.Locale;
 
 /**
  * The default security manager to ensure template code run in a secure mode
@@ -178,8 +179,8 @@ public class RythmSecurityManager extends SecurityManager {
         if (null != osm) osm.checkRead(file);
     }
     
-    private static final String BASE_RYTHM = RythmEngine.class.getResource(RythmEngine.class.getSimpleName() + ".class").getFile().replace("RythmEngine.class", "").toLowerCase(); 
-    private static final String BASE_JDK = Integer.class.getResource(Integer.class.getSimpleName() + ".class").getFile().replace("Integer.class", "").toLowerCase();
+    private static final String BASE_RYTHM = RythmEngine.class.getResource(RythmEngine.class.getSimpleName() + ".class").getFile().replace("RythmEngine.class", "").toLowerCase(Locale.US);
+    private static final String BASE_JDK = Integer.class.getResource(Integer.class.getSimpleName() + ".class").getFile().replace("Integer.class", "").toLowerCase(Locale.US);
     
     @Override
     public void checkWrite(String file) {


### PR DESCRIPTION
Keywords (import, args etc.) are in English. So it must be made lowered as such. I.e. In Turkish lower case of "I" is "ı" like, "IMPORT" lowered in Turkish is "ımport".