### PR TITLE
Fix for Pattern Exception on Android 7.0 API 24:

### DIFF
--- a/src/main/java/org/rythmengine/internal/parser/build_in/BraceParser.java
+++ b/src/main/java/org/rythmengine/internal/parser/build_in/BraceParser.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
  */
 public class BraceParser implements IParserFactory {
 
-    private final Pattern P = Pattern.compile("^((\\n[ \\t\\x0B\\f]*}[ \\t\\x0B\\f]*)\\n).*", Pattern.DOTALL);
+    private final Pattern P = Pattern.compile("^((\\n[ \\t\\x0B\\f]*\\}[ \\t\\x0B\\f]*)\\n).*", Pattern.DOTALL);
 
     @Override
     public IParser create(final IContext ctx) {


### PR DESCRIPTION
Caused by: java.util.regex.PatternSyntaxException: Syntax error in
regexp pattern near index 22
    ^((\n[ \t\x0B\f]*}[ \t\x0B\f]*)\n).*
                          ^
    at java.util.regex.Pattern.compileImpl(Native Method)