### PR TITLE
thread-safe , and change Stack to Deque

### DIFF
--- a/src/main/java/org/rythmengine/RythmEngine.java
+++ b/src/main/java/org/rythmengine/RythmEngine.java
@@ -42,6 +42,8 @@ import java.io.*;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -484,7 +486,7 @@ public class RythmEngine implements IEventDispatcher {
 
     // trim "rythm." from conf keys
     private Map<String, Object> _processConf(Map<String, ?> conf) {
-        Map<String, Object> m = new HashMap<String, Object>(conf.size());
+        Map<String, Object> m = new ConcurrentHashMap<String, Object>(conf.size());
         for (String s : conf.keySet()) {
             Object o = conf.get(s);
             if (s.startsWith("rythm.")) s = s.replaceFirst("rythm\\.", "");
@@ -554,7 +556,7 @@ public class RythmEngine implements IEventDispatcher {
         init(userConfiguration, null);
     }
 
-    private Map<String, Object> properties = new HashMap<String, Object>();
+    private Map<String, Object> properties = new ConcurrentHashMap<String, Object>();
 
     /**
      * Set user property to the engine. Note The property is not used by the engine program
@@ -608,7 +610,7 @@ public class RythmEngine implements IEventDispatcher {
                 }
             }
         }
-        return new HashMap();
+        return new ConcurrentHashMap();
     }
 
     private void init(Map<String, ?> conf, File file) {
@@ -1322,7 +1324,7 @@ public class RythmEngine implements IEventDispatcher {
         return toString(obj, option, ToStringStyle.fromApacheStyle(style));
     }
 
-    private Set<String> nonExistsTemplates = new HashSet<String>();
+    private Set<String> nonExistsTemplates = new CopyOnWriteArraySet<String>();
 
     private class NonExistsTemplatesChecker implements IShutdownListener {
         boolean started = false;
@@ -1427,7 +1429,7 @@ public class RythmEngine implements IEventDispatcher {
         return eval(script, Collections.<String, Object>emptyMap());
     }
 
-    private Map<String, Serializable> mvels = new HashMap<String, Serializable>();
+    private Map<String, Serializable> mvels = new ConcurrentHashMap<String, Serializable>();
 
     public Object eval(String script, Map<String, Object> params) {
         Serializable ce = mvels.get(script);
@@ -1451,9 +1453,9 @@ public class RythmEngine implements IEventDispatcher {
       Tags
     -------------------------------------------------------------------------------*/
 
-    private final Map<String, ITemplate> _templates = new HashMap<String, ITemplate>();
-    private final Map<String, JavaTagBase> _tags = new HashMap<String, JavaTagBase>();
-    private final Set<String> _nonTmpls = new HashSet<String>();
+    private final Map<String, ITemplate> _templates = new ConcurrentHashMap<String, ITemplate>();
+    private final Map<String, JavaTagBase> _tags = new ConcurrentHashMap<String, JavaTagBase>();
+    private final Set<String> _nonTmpls = new CopyOnWriteArraySet<String>();
 
     /**
      * Whether a {@link ITemplate template} is registered to the engine by name specified
@@ -1675,7 +1677,7 @@ public class RythmEngine implements IEventDispatcher {
         invokeTemplate(line, name, caller, params, body, context, false);
     }
 
-    private Set<String> _nonExistsTags = new HashSet<String>();
+    private Set<String> _nonExistsTags = new CopyOnWriteArraySet<String>();
 
     /**
      * Invoke a tag
@@ -1887,7 +1889,7 @@ public class RythmEngine implements IEventDispatcher {
 
     // -- SPI interface
     // -- issue #47
-    private Map<TemplateClass, Set<TemplateClass>> extendMap = new HashMap<TemplateClass, Set<TemplateClass>>();
+    private Map<TemplateClass, Set<TemplateClass>> extendMap = new ConcurrentHashMap<TemplateClass, Set<TemplateClass>>();
 
     /**
      * Not an API for user application
@@ -1899,7 +1901,7 @@ public class RythmEngine implements IEventDispatcher {
         if (mode().isProd()) return;
         Set<TemplateClass> children = extendMap.get(parent);
         if (null == children) {
-            children = new HashSet<TemplateClass>();
+            children = new CopyOnWriteArraySet<TemplateClass>();
             extendMap.put(parent, children);
         }
         children.add(child);

--- a/src/main/java/org/rythmengine/Sandbox.java
+++ b/src/main/java/org/rythmengine/Sandbox.java
@@ -11,8 +11,9 @@ import org.rythmengine.sandbox.RythmSecurityManager;
 import org.rythmengine.sandbox.SandboxExecutingService;
 
 import java.io.File;
+import java.util.Deque;
 import java.util.Map;
-import java.util.Stack;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
  * A wrapper of Rythm engine and make sure the rendering is happen in Sandbox mode
@@ -48,7 +49,7 @@ public class Sandbox {
         this.engine = engine;
         this.secureExecutor = executor;
         sandboxLive = true;
-        restrictedZone.set(new Stack<Boolean>());
+        restrictedZone.set(new ConcurrentLinkedDeque<Boolean>());
     }
     
     private static RythmSecurityManager rsm() {
@@ -92,10 +93,10 @@ public class Sandbox {
         return null;
     }
     
-    private final static ThreadLocal<Stack<Boolean>> restrictedZone = new ThreadLocal<Stack<Boolean>>(){
+    private final static ThreadLocal<Deque<Boolean>> restrictedZone = new ThreadLocal<Deque<Boolean>>(){
         @Override
-        protected Stack<Boolean> initialValue() {
-            return new Stack<Boolean>();
+        protected Deque<Boolean> initialValue() {
+            return new ConcurrentLinkedDeque<Boolean>();
         }
     };
     
@@ -114,7 +115,7 @@ public class Sandbox {
     public final static void leaveCurZone(String code) {
         if (!sandboxLive || !sandboxMode()) return;
         rsm().forbiddenIfCodeNotMatch(code);
-        Stack<Boolean> stack = restrictedZone.get();
+        Deque<Boolean> stack = restrictedZone.get();
         if (stack.isEmpty()) {
             throw new IllegalStateException("EMPTY ZONE");
         }
@@ -123,7 +124,7 @@ public class Sandbox {
     
     public final static boolean isRestricted() {
         if (!sandboxLive || !sandboxMode()) return false;
-        Stack<Boolean> stack = restrictedZone.get();
+        Deque<Boolean> stack = restrictedZone.get();
         if (stack.isEmpty()) return false;
         return stack.peek();
     }

--- a/src/main/java/org/rythmengine/internal/TemplateParser.java
+++ b/src/main/java/org/rythmengine/internal/TemplateParser.java
@@ -18,8 +18,9 @@ import org.rythmengine.logger.ILogger;
 import org.rythmengine.logger.Logger;
 import org.rythmengine.resource.TemplateResourceManager;
 
+import java.util.Deque;
 import java.util.Locale;
-import java.util.Stack;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class TemplateParser implements IContext {
     private final static ILogger logger = Logger.get(TemplateParser.class);
@@ -172,7 +173,7 @@ public class TemplateParser implements IContext {
         return template.substring(start, end);
     }
 
-    private Stack<IBlockHandler> blocks = new Stack<IBlockHandler>();
+    private Deque<IBlockHandler> blocks = new ConcurrentLinkedDeque<>();
 
     @Override
     public void openBlock(IBlockHandler bh) {
@@ -195,9 +196,8 @@ public class TemplateParser implements IContext {
 
     @Override
     public String currentSection() {
-        int len = blocks.size();
-        for (int i = len - 1; i >= 0; --i) {
-            IBlockHandler h = blocks.get(i);
+        while (!blocks.isEmpty()){
+            IBlockHandler h = blocks.pollLast();
             if (h instanceof SectionParser.SectionToken) {
                 return ((SectionParser.SectionToken)h).section();
             }
@@ -220,11 +220,11 @@ public class TemplateParser implements IContext {
 
     @Override
     public boolean compactMode() {
-        if (!compactStack.empty()) return compactStack.peek();
+        if (!compactStack.isEmpty()) return compactStack.peek();
         return compactMode;
     }
 
-    private Stack<Boolean> compactStack = new Stack<Boolean>();
+    private Deque<Boolean> compactStack = new ConcurrentLinkedDeque<>();
 
     @Override
     public void pushCompact(Boolean compact) {
@@ -233,17 +233,17 @@ public class TemplateParser implements IContext {
 
     @Override
     public Boolean peekCompact() {
-        if (compactStack.empty()) return null;
+        if (compactStack.isEmpty()) return null;
         return compactStack.peek();
     }
 
     @Override
     public Boolean popCompact() {
-        if (compactStack.empty()) return null;
+        if (compactStack.isEmpty()) return null;
         return compactStack.pop();
     }
 
-    private Stack<Break> breakStack = new Stack<Break>();
+    private Deque<Break> breakStack = new ConcurrentLinkedDeque<>();
 
     @Override
     public void pushBreak(Break b) {
@@ -252,17 +252,17 @@ public class TemplateParser implements IContext {
 
     @Override
     public Break peekBreak() {
-        if (breakStack.empty()) return null;
+        if (breakStack.isEmpty()) return null;
         return breakStack.peek();
     }
 
     @Override
     public Break popBreak() {
-        if (breakStack.empty()) return null;
+        if (breakStack.isEmpty()) return null;
         return breakStack.pop();
     }
 
-    private Stack<Continue> continueStack = new Stack<Continue>();
+    private Deque<Continue> continueStack = new ConcurrentLinkedDeque<>();
 
     @Override
     public void pushContinue(Continue b) {
@@ -271,23 +271,23 @@ public class TemplateParser implements IContext {
 
     @Override
     public Continue peekContinue() {
-        if (continueStack.empty()) return null;
+        if (continueStack.isEmpty()) return null;
         return continueStack.peek();
     }
 
     @Override
     public Continue popContinue() {
-        if (continueStack.empty()) return null;
+        if (continueStack.isEmpty()) return null;
         return continueStack.pop();
     }
 
     @Override
     public boolean insideBody() {
-        if (!inBodyStack.empty()) return inBodyStack.peek();
+        if (!inBodyStack.isEmpty()) return inBodyStack.peek();
         return false;
     }
 
-    private Stack<Boolean> inBodyStack = new Stack<Boolean>();
+    private Deque<Boolean> inBodyStack = new ConcurrentLinkedDeque<>();
 
     @Override
     public void pushInsideBody(Boolean b) {
@@ -296,23 +296,23 @@ public class TemplateParser implements IContext {
 
     @Override
     public Boolean peekInsideBody() {
-        if (inBodyStack.empty()) return false;
+        if (inBodyStack.isEmpty()) return false;
         return inBodyStack.peek();
     }
 
     @Override
     public Boolean popInsideBody() {
-        if (inBodyStack.empty()) return null;
+        if (inBodyStack.isEmpty()) return null;
         return inBodyStack.pop();
     }
 
     @Override
     public boolean insideBody2() {
-        if (!inBodyStack2.empty()) return inBodyStack2.peek();
+        if (!inBodyStack2.isEmpty()) return inBodyStack2.peek();
         return false;
     }
 
-    private Stack<Boolean> inBodyStack2 = new Stack<Boolean>();
+    private Deque<Boolean> inBodyStack2 = new ConcurrentLinkedDeque<>();
 
     @Override
     public void pushInsideBody2(Boolean b) {
@@ -321,13 +321,13 @@ public class TemplateParser implements IContext {
 
     @Override
     public Boolean peekInsideBody2() {
-        if (inBodyStack2.empty()) return false;
+        if (inBodyStack2.isEmpty()) return false;
         return inBodyStack2.peek();
     }
 
     @Override
     public Boolean popInsideBody2() {
-        if (inBodyStack2.empty()) return null;
+        if (inBodyStack2.isEmpty()) return null;
         return inBodyStack2.pop();
     }
 
@@ -348,7 +348,7 @@ public class TemplateParser implements IContext {
         insideDirectiveComment = false;
     }
 
-    private Stack<ICodeType> codeTypeStack = new Stack<ICodeType>();
+    private Deque<ICodeType> codeTypeStack = new ConcurrentLinkedDeque<>();
 
     @Override
     public ICodeType peekCodeType() {
@@ -376,7 +376,7 @@ public class TemplateParser implements IContext {
         return cur;
     }
 
-    private Stack<Locale> localeStack = new Stack<Locale>();
+    private Deque<Locale> localeStack = new ConcurrentLinkedDeque<>();
 
     @Override
     public Locale peekLocale() {

--- a/src/main/java/org/rythmengine/internal/compiler/TemplateClass.java
+++ b/src/main/java/org/rythmengine/internal/compiler/TemplateClass.java
@@ -9,12 +9,12 @@ import java.io.File;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,9 +68,9 @@ public class TemplateClass {
      */
     private String name;
     public TemplateClass extendedTemplateClass;
-    private Set<TemplateClass> includedTemplateClasses = new HashSet<TemplateClass>();
+    private Set<TemplateClass> includedTemplateClasses = new CopyOnWriteArraySet<TemplateClass>();
     private String includeTemplateClassNames = null;
-    private Map<String, String> includeTagTypes = new HashMap<String, String>();
+    private Map<String, String> includeTagTypes = new ConcurrentHashMap<String, String>();
     private String tagName;
 
     /**
@@ -238,7 +238,7 @@ public class TemplateClass {
      * WRITE : includeTagTypes
      */
     public void deserializeIncludeTagTypes(String s) {
-        includeTagTypes = new HashMap<String, String>();
+        includeTagTypes = new ConcurrentHashMap<String, String>();
         if (S.isEmpty(s)) {
             return;
         }
@@ -449,7 +449,7 @@ public class TemplateClass {
 
     public void buildSourceCode(String includingClassName) {
         long start = System.currentTimeMillis();
-        importPaths = new HashSet<String>();
+        importPaths = new CopyOnWriteArraySet<String>();
         // Possible bug here?
         if (null != codeBuilder) codeBuilder.clear();
         codeBuilder = new CodeBuilder(templateResource.asTemplateContent(), name(), tagName, this, engine, dialect);
@@ -464,7 +464,7 @@ public class TemplateClass {
 
     public void buildSourceCode() {
         long start = System.currentTimeMillis();
-        importPaths = new HashSet<String>();
+        importPaths = new CopyOnWriteArraySet<String>();
         // Possible bug here?
         if (null != codeBuilder) {
             codeBuilder.clear();

--- a/src/main/java/org/rythmengine/internal/compiler/TemplateClassCache.java
+++ b/src/main/java/org/rythmengine/internal/compiler/TemplateClassCache.java
@@ -16,8 +16,8 @@ import org.rythmengine.utils.TextBuilder;
 import java.io.*;
 import java.net.URI;
 import java.security.MessageDigest;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * Used to speed up compilation time
@@ -120,7 +120,7 @@ public class TemplateClassCache {
                 if (sa.length > 1) {
                     s = sa[1];
                     sa = s.split(";");
-                    Set<String> importPaths = new HashSet<String>();
+                    Set<String> importPaths = new CopyOnWriteArraySet<String>();
                     for (String path : sa) {
                         if ("java.lang".equals(path)) continue;
                         importPaths.add(path);
@@ -180,7 +180,7 @@ public class TemplateClassCache {
                 tb.p("__INCULDED_TEMPLATE_CLASS_NAME_LIST__").p(tc.refreshIncludeTemplateClassNames())
                         .p("__IMPORT_PATH_LIST__");
                 if (tc.importPaths == null) {
-                    tc.importPaths = new HashSet<String>(0);
+                    tc.importPaths = new CopyOnWriteArraySet<String>();
                 }
                 if (tc.importPaths.isEmpty()) {
                     tc.importPaths.add("java.lang");

--- a/src/main/java/org/rythmengine/internal/compiler/TemplateClassLoader.java
+++ b/src/main/java/org/rythmengine/internal/compiler/TemplateClassLoader.java
@@ -22,6 +22,8 @@ import java.io.InputStream;
 import java.lang.instrument.ClassDefinition;
 import java.security.ProtectionDomain;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -68,7 +70,7 @@ public class TemplateClassLoader extends ClassLoader {
             }
         }
 
-        private final Map<File, FileWithClassDefs> classDefsInFileCache = new HashMap<File, FileWithClassDefs>();
+        private final Map<File, FileWithClassDefs> classDefsInFileCache = new ConcurrentHashMap<File, FileWithClassDefs>();
 
         public synchronized int computePathHash(File... paths) {
             StringBuilder buf = new StringBuilder();
@@ -448,7 +450,7 @@ public class TemplateClassLoader extends ClassLoader {
         for (TemplateClass tc : engine.classes().all()) {
             if (tc.refresh()) modifieds.add(tc);
         }
-        Set<TemplateClass> modifiedWithDependencies = new HashSet<TemplateClass>();
+        Set<TemplateClass> modifiedWithDependencies = new CopyOnWriteArraySet<TemplateClass>();
         modifiedWithDependencies.addAll(modifieds);
         List<ClassDefinition> newDefinitions = new ArrayList<ClassDefinition>();
         boolean dirtySig = false;

--- a/src/main/java/org/rythmengine/internal/compiler/TemplateClassManager.java
+++ b/src/main/java/org/rythmengine/internal/compiler/TemplateClassManager.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Created by IntelliJ IDEA.
@@ -37,7 +39,7 @@ public class TemplateClassManager {
     /**
      * Index template class with class name
      */
-    public Map<String, TemplateClass> clsNameIdx = new HashMap<String, TemplateClass>();
+    public Map<String, TemplateClass> clsNameIdx = new ConcurrentHashMap<String, TemplateClass>();
     /**
      * Index template class with inline template content or template file name
      */
@@ -53,7 +55,7 @@ public class TemplateClassManager {
      * Clear the classCache cache
      */
     public void clear() {
-        clsNameIdx = new HashMap<String, TemplateClass>();
+        clsNameIdx = new ConcurrentHashMap<String, TemplateClass>();
         tmplIdx = new HashMap<Object, TemplateClass>();
     }
 
@@ -63,7 +65,7 @@ public class TemplateClassManager {
      * @return All loaded classes
      */
     public List<TemplateClass> all() {
-        return new ArrayList<TemplateClass>(clsNameIdx.values());
+        return new CopyOnWriteArrayList<TemplateClass>(clsNameIdx.values());
     }
 
     /**

--- a/src/main/java/org/rythmengine/internal/dialect/DialectManager.java
+++ b/src/main/java/org/rythmengine/internal/dialect/DialectManager.java
@@ -13,7 +13,8 @@ import org.rythmengine.logger.ILogger;
 import org.rythmengine.logger.Logger;
 import org.rythmengine.utils.S;
 
-import java.util.Stack;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class DialectManager {
     protected final static ILogger logger = Logger.get(DialectManager.class);
@@ -45,10 +46,10 @@ public class DialectManager {
         return defDialects[i];
     }
 
-    private static final InheritableThreadLocal<Stack<IDialect>> cur = new InheritableThreadLocal<Stack<IDialect>>() {
+    private static final InheritableThreadLocal<Deque<IDialect>> cur = new InheritableThreadLocal<Deque<IDialect>>() {
         @Override
-        protected Stack<IDialect> initialValue() {
-            return new Stack<IDialect>();
+        protected Deque<IDialect> initialValue() {
+            return new ConcurrentLinkedDeque<>();
         }
     };
 
@@ -62,7 +63,7 @@ public class DialectManager {
     }
 
     private static IDialect pop() {
-        Stack<IDialect> sd = cur.get();
+        Deque<IDialect> sd = cur.get();
         IDialect d = sd.pop();
         if (sd.isEmpty()) {
             cur.remove();

--- a/src/main/java/org/rythmengine/sandbox/RythmSecurityManager.java
+++ b/src/main/java/org/rythmengine/sandbox/RythmSecurityManager.java
@@ -261,13 +261,13 @@ public class RythmSecurityManager extends SecurityManager {
         if (null != osm) osm.checkPropertyAccess(key);
     }
 
-    @Override
-    public boolean checkTopLevelWindow(Object window) {
-        checkRythm();
-        if (null != csm) return csm.checkTopLevelWindow(window);
-        else if (null != osm) return osm.checkTopLevelWindow(window);
-        else return true;
-    }
+//    @Override
+//    public boolean checkTopLevelWindow(Object window) {
+//        checkRythm();
+//        if (null != csm) return csm.checkTopLevelWindow(window);
+//        else if (null != osm) return osm.checkTopLevelWindow(window);
+//        else return true;
+//    }
 
     @Override
     public void checkPrintJobAccess() {
@@ -276,19 +276,19 @@ public class RythmSecurityManager extends SecurityManager {
         if (null != osm) osm.checkPrintJobAccess();
     }
 
-    @Override
-    public void checkSystemClipboardAccess() {
-        checkRythm();
-        if (null != osm) osm.checkSystemClipboardAccess();
-        if (null != csm) csm.checkSystemClipboardAccess();
-    }
+//    @Override
+//    public void checkSystemClipboardAccess() {
+//        checkRythm();
+//        if (null != osm) osm.checkSystemClipboardAccess();
+//        if (null != csm) csm.checkSystemClipboardAccess();
+//    }
 
-    @Override
-    public void checkAwtEventQueueAccess() {
-        checkRythm();
-        if (null != osm) osm.checkAwtEventQueueAccess();
-        if (null != csm) csm.checkAwtEventQueueAccess();
-    }
+//    @Override
+//    public void checkAwtEventQueueAccess() {
+//        checkRythm();
+//        if (null != osm) osm.checkAwtEventQueueAccess();
+//        if (null != csm) csm.checkAwtEventQueueAccess();
+//    }
 
     @Override
     public void checkPackageAccess(String pkg) {
@@ -334,12 +334,12 @@ public class RythmSecurityManager extends SecurityManager {
         if (null != csm) csm.checkPermission(perm);
     }
 
-    @Override
-    public void checkMemberAccess(Class<?> clazz, int which) {
-        if (null != osm) osm.checkMemberAccess(clazz, which);
-        if (null != csm) csm.checkMemberAccess(clazz, which);
-        //Todo check rythm member access
-    }
+//    @Override
+//    public void checkMemberAccess(Class<?> clazz, int which) {
+//        if (null != osm) osm.checkMemberAccess(clazz, which);
+//        if (null != csm) csm.checkMemberAccess(clazz, which);
+//        //Todo check rythm member access
+//    }
 
     @Override
     public void checkSetFactory() {

--- a/src/main/java/org/rythmengine/template/ITemplate.java
+++ b/src/main/java/org/rythmengine/template/ITemplate.java
@@ -16,6 +16,7 @@ import org.rythmengine.utils.JSONWrapper;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
  * Define a template instance API
@@ -215,18 +216,18 @@ public interface ITemplate extends ITag, Cloneable {
          * 
          * @see {@link #localeStack}
          */
-        private Deque<ICodeType> codeTypeStack = new ArrayDeque<ICodeType>();
+        private Deque<ICodeType> codeTypeStack = new ConcurrentLinkedDeque<ICodeType>();
 
         /**
          * template escape stack. Used to enable the
          * {@link org.rythmengine.conf.RythmConfigurationKey#FEATURE_SMART_ESCAPE_ENABLED}
          */
-        private Deque<Escape> escapeStack = new ArrayDeque<Escape>();
+        private Deque<Escape> escapeStack = new ConcurrentLinkedDeque<Escape>();
 
         /**
          * template locale stack. Used to track the locale in the current context.
          */
-        private Deque<Locale> localeStack = new ArrayDeque<Locale>();
+        private Deque<Locale> localeStack = new ConcurrentLinkedDeque<Locale>();
 
         private TemplateBase tmpl;
         

--- a/src/main/java/org/rythmengine/template/TemplateBase.java
+++ b/src/main/java/org/rythmengine/template/TemplateBase.java
@@ -28,6 +28,8 @@ import java.io.*;
 import java.lang.reflect.Array;
 import java.lang.reflect.Modifier;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
  * The base class of template implementation. It provides a set of
@@ -126,7 +128,7 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
      * will also declare render args as separate protected field while keeping
      * a copy inside this Map data structure
      */
-    protected Map<String, Object> __renderArgs = new HashMap<String, Object>();
+    protected Map<String, Object> __renderArgs = new ConcurrentHashMap<String, Object>();
 
     /**
      * Return the {@link RythmEngine engine} running this template
@@ -245,10 +247,10 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
     /* to be used by dynamic generated sub classes */
     private String layoutContent = "";
     // store the current template section content
-    private Map<String, String> layoutSections = new HashMap<String, String>();
+    private Map<String, String> layoutSections = new ConcurrentHashMap<String, String>();
     // store the parent default section content
-    private Map<String, String> layoutSections0 = new HashMap<String, String>();
-    private Map<String, Object> renderProperties = new HashMap<String, Object>();
+    private Map<String, String> layoutSections0 = new ConcurrentHashMap<String, String>();
+    private Map<String, Object> renderProperties = new ConcurrentHashMap<String, Object>();
 
     /**
      * The parent template (layout template)
@@ -449,11 +451,11 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
         tmpl.__ctx = new __Context();
         //if (null != buffer) tmpl.__buffer = buffer;
         if (null != __buffer) tmpl.__buffer = new StringBuilder();
-        tmpl.__renderArgs = new HashMap<String, Object>(__renderArgs.size());
+        tmpl.__renderArgs = new ConcurrentHashMap<String, Object>(__renderArgs.size());
         //tmpl.layoutContent = "";
-        tmpl.layoutSections = new HashMap<String, String>();
-        tmpl.layoutSections0 = new HashMap<String, String>();
-        tmpl.renderProperties = new HashMap<String, Object>();
+        tmpl.layoutSections = new ConcurrentHashMap<String, String>();
+        tmpl.layoutSections0 = new ConcurrentHashMap<String, String>();
+        tmpl.renderProperties = new ConcurrentHashMap<String, Object>();
         //tmpl.section = null;
         //tmpl.tmpCaller = null;
         //tmpl.tmpOut = null;
@@ -1399,7 +1401,7 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
     }
 
     protected final Object __eval(String expr) {
-        Map<String, Object> ctx = new HashMap<String, Object>(__renderArgs);
+        Map<String, Object> ctx = new ConcurrentHashMap<String, Object>(__renderArgs);
         ctx.putAll(itrVars());
         try {
             Object retval = __engine().eval(expr, this, ctx);
@@ -1450,7 +1452,7 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
         return i18n.getMessage(TemplateBase.this, key, args);
     }
 
-    private Deque<F.T2<String, Object>> itrVars = new ArrayDeque<>();
+    private Deque<F.T2<String, Object>> itrVars = new ConcurrentLinkedDeque<>();
 
     protected void __pushItrVar(String name, Object val) {
         itrVars.push(F.T2(name, val));
@@ -1463,8 +1465,8 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
     private Map<String, Object> itrVars() {
         if (itrVars.isEmpty()) return Collections.EMPTY_MAP;
         if (itrVars.size() == 1) return itrVars.peek().asMap();
-        Deque<F.T2<String, Object>> tmp = new ArrayDeque<>();
-        Map<String, Object> m = new HashMap<String, Object>();
+        Deque<F.T2<String, Object>> tmp = new ConcurrentLinkedDeque<>();
+        Map<String, Object> m = new ConcurrentHashMap<String, Object>();
         Deque<F.T2<String, Object>> vs = itrVars;
         while (!vs.isEmpty()) {
             F.T2<String, Object> var = vs.pop();


### PR DESCRIPTION
Sometimes use the engine for multithreading class 'FutureTask' , but it 's not work , even show errors like 
`at java.base/java.util.ArrayDeque.push(ArrayDeque.java:580)
        at org.rythmengine.template.TemplateBase.__pushItrVar(TemplateBase.java:1455)`
        
So , do some change to update class for thread-safe ,as update `ArrayDeque` to `ConcurrentLinkedDeque` , some `HashMap` to `ConcurrentHashMap` , some `HashSet` to `CopyOnWriteArraySet` , at the same time , update `Stack` to `Deque` , use `ConcurrentLinkedDeque` instead of . And it works for me. 

Or maybe should create new branch for thread-safe.

