### PR TITLE
Update pom.xml to use mvel2 v2.4.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 		<dependency>
 			<groupId>org.mvel</groupId>
 			<artifactId>mvel2</artifactId>
-			<version>2.2.8.Final</version>
+			<version>2.4.12.Final</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
mvel2 has been updated to compile with JDK 9 and beyond. 