### PR TITLE
Add null check for value as well in renderArgs in RythmEngine

### DIFF
--- a/src/main/java/org/rythmengine/RythmEngine.java
+++ b/src/main/java/org/rythmengine/RythmEngine.java
@@ -1779,7 +1779,7 @@ public class RythmEngine implements IEventDispatcher {
                 } else {
                     for (int i = 0; i < params.size(); ++i) {
                         ITag.__Parameter param = params.get(i);
-                        if (null != param.name) {
+                        if (null != param.name && null != param.value) {
                             t.__setRenderArg(param.name, param.value);
                         } else if (null != param.value) {
                             t.__setRenderArg(i, param.value);

--- a/src/main/java/org/rythmengine/RythmEngine.java
+++ b/src/main/java/org/rythmengine/RythmEngine.java
@@ -1779,8 +1779,11 @@ public class RythmEngine implements IEventDispatcher {
                 } else {
                     for (int i = 0; i < params.size(); ++i) {
                         ITag.__Parameter param = params.get(i);
-                        if (null != param.name) t.__setRenderArg(param.name, param.value);
-                        else t.__setRenderArg(i, param.value);
+                        if (null != param.name) {
+                            t.__setRenderArg(param.name, param.value);
+                        } else if (null != param.value) {
+                            t.__setRenderArg(i, param.value);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
ConcurrentHashMap does not allow for null keys and values. This introduced a regression in our use-case so adding a null check to resolve null value check.