### PR TITLE
fix memory leak - @for - else directive

### DIFF
--- a/src/main/java/org/rythmengine/internal/parser/build_in/ElseForParser.java
+++ b/src/main/java/org/rythmengine/internal/parser/build_in/ElseForParser.java
@@ -67,7 +67,7 @@ public class ElseForParser extends CaretParserFactoryBase {
 
                 try {
                     ctx.closeBlock();
-                    s1 = "\n\t}\n} else {\n";
+                    s1 = "\n\t__popItrVar();\n\t}\n} else {\n";
                 } catch (ParseException e) {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/org/rythmengine/template/TemplateBase.java
+++ b/src/main/java/org/rythmengine/template/TemplateBase.java
@@ -498,6 +498,9 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
             }
         }
         tmpl.__setUserContext(engine.renderSettings.userContext());
+
+        tmpl.itrVars = new ConcurrentLinkedDeque<>();
+
         return tmpl;
     }
 


### PR DESCRIPTION
## Case
When generating code for `@for ~ else` directive,  `__pushItrVar()` method invocation 
is inserted at loop body start, but `__popItrVar()` is not inserted at body end. 
This causes `itrVars` deque to keep growing. 
(sole `@for` case, both methods are properly inserted, so no such issues exist)

Moreover, when cloning `TemplateBase`, `itrVars` instance variable is shallowly cloned, so is shared. 
So `itrVars` keeps growing, resulting OOM

## Fix
* add `__popItrVar()` method invocation at `ElseForParser`
* newly create `itrVars` when `TemplateBase` is cloned